### PR TITLE
No Jobs in sharq should not raise an error

### DIFF
--- a/sharq.go
+++ b/sharq.go
@@ -197,7 +197,7 @@ func (c *Client) Dequeue(queueType string) (*DequeueResponse, error) {
 			return nil, err
 		}
 	case http.StatusNotFound:
-		return nil, errors.New("No Jobs Found")
+		return nil, nil
 	case http.StatusBadRequest:
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		if err != nil {


### PR DESCRIPTION
This is done because this non-error fills up the logs