### PR TITLE
Enclose payload within quotes to make go-sharq compatible with sharq-server

### DIFF
--- a/core.go
+++ b/core.go
@@ -1,6 +1,7 @@
 package sharq
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -109,7 +110,7 @@ func (c *CoreClient) Enqueue(e *EnqueueRequest) EnqueueResponse {
 		// Keys
 		[]string{c.config.KeyPrefix, e.QueueType},
 		// Args
-		timestamp, e.QueueID, e.JobID, string(serialized_payload),
+		timestamp, e.QueueID, e.JobID, fmt.Sprintf("\"%s\"", string(serialized_payload)),
 		e.Interval, requeue_limit,
 	).Result()
 	if err != nil {
@@ -149,7 +150,8 @@ func (c *CoreClient) Dequeue(queueType string) (*DequeueResponse, error) {
 		return nil, nil
 	}
 
-	deserialized_payload, err := deserializePayload(dequeue_response[2].(string))
+	raw_dequeue_response := dequeue_response[2].(string)
+	deserialized_payload, err := deserializePayload(raw_dequeue_response[1 : len(raw_dequeue_response)-1])
 	if err != nil {
 		return nil, err
 	}

--- a/core_test.go
+++ b/core_test.go
@@ -94,7 +94,7 @@ func TestCoreEnqueuePayload(t *testing.T) {
 	raw_payload, err := testCoreClient.redisclient.HGet(payload_map_name, payload_map_key).Result()
 	assert.NoError(t, err)
 	// decode the payload from msgpack to dictionary
-	payload, err := deserializePayload(raw_payload)
+	payload, err := deserializePayload(raw_payload[1 : len(raw_payload)-1])
 	assert.Equal(t, testPayload1, payload)
 }
 
@@ -344,7 +344,7 @@ func TestCoreEnqueueSecondJobPayload(t *testing.T) {
 	raw_payload, err := testCoreClient.redisclient.HGet(payload_map_name, payload_map_key).Result()
 	assert.NoError(t, err)
 	// decode the payload from msgpack to dictionary
-	payload, err := deserializePayload(raw_payload)
+	payload, err := deserializePayload(raw_payload[1 : len(raw_payload)-1])
 	assert.Equal(t, testPayload2, payload)
 }
 


### PR DESCRIPTION
Based on payload formatting
during enqueue: https://github.com/plivo/sharq/blob/master/sharq/queue.py#L168
and dequeue: https://github.com/plivo/sharq/blob/master/sharq/queue.py#L208

Unsure why this was done. Adding these to maintain compatibility.